### PR TITLE
Simple terms

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "leanprover-community/lean:3.9.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "e918f726cfc12a352f6655371b21675d001bc601"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "d1eae21454202855aeeda028bd9c39d45c57b6ed"}

--- a/src/TL.lean
+++ b/src/TL.lean
@@ -1,4 +1,3 @@
-import data.finset
 namespace TT
 
 inductive type : Type
@@ -6,63 +5,37 @@ inductive type : Type
 
 notation `Ω` := type.Omega
 notation `𝟙` := type.One
-infix `××` :100 := type.Prod
-prefix 𝒫 :101 := type.Pow
+infix `××`:max := type.Prod
+prefix 𝒫 :max := type.Pow
 
 def context := list type
 
-inductive term : context → type → Type
-| var (Γ A Δ) : term (list.append Γ (A::Δ)) A
-| comp {Γ} : Π A : type, term (A::Γ) Ω → term Γ (𝒫 A)
-| all  {Γ} : Π A : type, term (A::Γ) Ω → term Γ Ω
-| ex   {Γ} : Π A : type, term (A::Γ) Ω → term Γ Ω
-| star {Γ} : term Γ 𝟙
-| top  {Γ} : term Γ Ω
-| bot  {Γ} : term Γ Ω
-| prod {Γ} : Π {A B : type}, term Γ A → term Γ B → term Γ (A ×× B)
-| elem {Γ} : Π {A : type}, term Γ A → term Γ (𝒫 A) → term Γ Ω
-| and  {Γ} : term Γ Ω → term Γ Ω → term Γ Ω
-| or   {Γ} : term Γ Ω → term Γ Ω → term Γ Ω
-| imp  {Γ} : term Γ Ω → term Γ Ω → term Γ Ω
-| fake_eq {Γ} : Π (A : type), term Γ A → term Γ A → term Γ Ω
+inductive term : Type
+| star : term
+| top  : term
+| bot  : term
+| and  : term → term → term
+| or   : term → term → term
+| imp  : term → term → term
+| var  : ℕ → term
+| comp : term → term
+| all  : term → term
+| ex   : term → term
+| elem : term → term → term
+| prod : term → term → term
 
 open term
 
--- def add_junk (β : context) : Π (Γ: context) (A: type), term Γ A → term (list.append Γ β) A
--- | (list.append Γ (A::Δ)) (A) (var Γ A Δ) := var Γ A (list.append Δ β)
-
--- #check var [𝟙,Ω] 𝟙 []
--- #check var [] 𝟙 [Ω,𝟙]
-
--- -- x == y
--- def x_eq_y
---   := fake_eq 𝟙 (var [𝟙,Ω] 𝟙 []) (var [] 𝟙 [Ω,𝟙])
-
--- #check x_eq_y
-
--- -- x == y
--- def x_eq_y
---   := fake_eq [𝟙,Ω,𝟙] 𝟙 (var [𝟙,Ω] 𝟙 []) (var [] 𝟙 [Ω,𝟙])
-
--- -- -- (∀ y ∈ 𝟙) x == y
--- def forall_y_x_eq_y
---   := all [Ω,𝟙] 𝟙 x_eq_y
-
--- -- -- p ∨ (∀ y ∈ 𝟙) x == y
--- def p_or_forall_y_x_eq_y
---   := or [Ω, 𝟙] (var [] Ω [𝟙]) forall_y_x_eq_y
-
--- -- -- (∀ p ∈ Ω) (p ∨ (∀ y ∈ 𝟙) x == y)
--- def forall_p_p_or_forall_y_x_eq_y
---   := all [𝟙] Ω p_or_forall_y_x_eq_y
-
--- -- (∀ x ∈ 𝟙) (∀ p ∈ Ω) (p ∨ (∀ y ∈ 𝟙) x == y)
--- def forall_x_forall_p_p_or_forall_y_x_eq_y
---   := all [] 𝟙 forall_p_p_or_forall_y_x_eq_y
-
--- #check forall_x_forall_p_p_or_forall_y_x_eq_y
-
--- infix `∶` :max :=  var -- input \:
+notation `<0>` := var 0
+notation `<1>` := var 1
+notation `<2>` := var 2
+notation `<3>` := var 3
+notation `<4>` := var 4
+notation `<5>` := var 5
+notation `<6>` := var 6
+notation `<7>` := var 7
+notation `<8>` := var 8
+notation `<9>` := var 9
 
 notation `⁎` := star    -- input \asterisk
 notation `⊤` := top     --       \top
@@ -71,124 +44,122 @@ infixr ` ⟹ `:60 := imp -- input \==>
 infixr ` ∧' ` :70 := and -- input \wedge'
 infixr ` ∨' ` :59 := or  -- input \vee'
 
-def not (p : term Ω) := p ⟹ ⊥
+def not (p : term) := p ⟹ ⊥
 prefix `∼`:max := not -- input \~, the ASCII character ~ has too low precedence
 
-def biimp (p q: term Ω) := and (p ⟹ q) (q ⟹ p)
+def biimp (p q: term) := and (p ⟹ q) (q ⟹ p)
 infix ` ⇔ `:60 := biimp -- input \<=>
 
-notation `<` a `,` b `>` := prod a b
+infix ∈ := elem
+infix ∉ := λ a, λ α, not (elem a α)
+notation `⁅` φ `⁆` := comp φ
 
-notation a ∈ α := elem a α
-notation a ∉ α := ∼ (elem a α)
-notation `[` A `|` φ `]` := comp A φ
+prefix `∀'`:1 := all 
+prefix `∃'`:2 := ex 
 
-notation `∀'` := all 
-notation `∃'` := ex 
-
-def eq {A : type} (a : term A) (a' : term A) : term Ω :=
-  all (𝒫 A) (a ∈ (0∶(𝒫 A))) ⇔ (a' ∈ (0∶(𝒫 A)))
+def eq (a : term) (a' : term) : term := ∀' (a ∈ <0>) ⇔ (a' ∈ <0>)
 infix `≃` :50 := eq
 
-def singleton {A : type} (a : term A) : term (𝒫 A) := comp A $ a ≃ 0∶A
-notation `[` a `]` := singleton a
+def singleton (a : term) := ⁅a ≃ (<0>)⁆
 
-def ex_unique (A : type) (φ : term Ω) : term Ω :=
-  ∃' A $ [A | φ] ≃ [3∶A]
-notation `∃!'` := ex_unique
+def ex_unique (φ : term) : term :=
+  ∃' ⁅φ⁆ ≃ singleton (<3>)
+prefix `∃!'`:2 := ex_unique
 
-#check ex_unique 𝟙 ⊤
-
-def subseteq {A : type} (α : term 𝒫 A) (β : term 𝒫 A) : term Ω :=
-  ∀' A $ (0∶A ∈ α) ⟹ (0∶A ∈ β)
+def subseteq (α : term) (β : term) : term :=
+  ∀' (<0> ∈ α) ⟹ (<0> ∈ β)
 infix ⊆ := subseteq
 
-def lift (d : ℕ) : ℕ → Π {A : type}, term A → term A
-| k _ (var n A)  := var (if k ≤ n then (n+d) else n) A
-| k _ (comp A φ) := comp A (lift (k+1) φ)
-| k _ (∀' A φ)   := ∀' A (lift (k+1) φ)
-| k _ (∃' A φ)   := ∃' A (lift (k+1) φ)
--- pass through the rest unchanged
-| k _ ⁎          := ⁎
-| k _ top        := top
-| k _ bot        := bot
-| k _ (prod a b) := prod (lift k a) (lift k b)
-| k _ (a ∈ α)    := (lift k a) ∈ (lift k α)
-| k _ (p ∧' q)   := (lift k p) ∧' (lift k q)
-| k _ (p ∨' q)   := (lift k p) ∨' (lift k q)
-| k _ (p ⟹ q)  := (lift k p) ⟹ (lift k q)
+inductive WF : context → term → type → Prop
+| star {Γ}           : WF Γ term.star 𝟙
+| top  {Γ}           : WF Γ term.top Ω
+| bot  {Γ}           : WF Γ term.bot Ω
+| and  {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (term.and e₁ e₂) Ω
+| or   {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (term.or e₁ e₂) Ω
+| imp  {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (term.imp e₁ e₂) Ω
+| var  {Γ n A}       : list.nth Γ n = some A → WF Γ (term.var n) A
+| comp {Γ e A}       : WF (A::Γ) e Ω → WF Γ (term.comp e) (𝒫 A)
+| all  {Γ e A}       : WF (A::Γ) e Ω → WF Γ (term.all e) Ω
+| ex   {Γ e A}       : WF (A::Γ) e Ω → WF Γ (term.all e) Ω
+| elem {Γ e₁ e₂ A}   : WF Γ e₁ A → WF Γ e₂ (𝒫 A) → WF Γ (term.elem e₁ e₂) Ω
+| prod {Γ e₁ e₂ A B} : WF Γ e₁ A → WF Γ e₂ B → WF Γ (term.prod e₁ e₂) (A ×× B)
 
--- Substitution is hard - how to resolve when A should be S?
--- problem arises because `term` allows ∀' A (var 0 B), which is not well-formed
+def subst_nth (b:term) : ℕ → term → term
+| n star       := star
+| n top        := top
+| n bot        := bot
+| n (and p q)  := and (subst_nth n p) (subst_nth n q)
+| n (or p q)   := or (subst_nth n p) (subst_nth n q)
+| n (imp p q)  := imp (subst_nth n p) (subst_nth n q)
+| n (var m)    := if n=m then b else var m
+| n (comp φ)   := comp (subst_nth (n+1) φ)
+| n (all φ)    := all (subst_nth (n+1) φ)
+| n (ex φ)     := ex (subst_nth (n+1) φ)
+| n (elem a α) := elem (subst_nth n a) (subst_nth n α)
+| n (prod a b) := prod (subst_nth n a) (subst_nth n b)
 
--- def subst {A S: type} (s : term S) : ℕ → term A → term A
--- | k (var n _) := if n=k then s else (var n _)
+def subst (b:term):= subst_nth b 0
 
+def remap_vars : Π k : ℕ, (ℕ → ℕ) → term → term
+| k σ top        := top
+| k σ star       := star
+| k σ bot        := bot
+| k σ (p ∧' q)   := (remap_vars k σ p) ∧' (remap_vars k σ q)
+| k σ (p ∨' q)   := (remap_vars k σ p) ∨' (remap_vars k σ q)
+| k σ (p ⟹ q)  := (remap_vars k σ p) ⟹ (remap_vars k σ q)
+| k σ (var m)    := var (σ (m+k))
+| k σ (⁅φ⁆)      := ⁅(remap_vars (k+1) σ φ)⁆
+| k σ (∀' φ)     := ∀' (remap_vars (k+1) σ φ)
+| k σ (∃' φ)     := ex (remap_vars (k+1) σ φ)
+| k σ (a ∈ α)    := (remap_vars k σ a) ∈ (remap_vars k σ α)
+| k σ (prod a b) := prod (remap_vars k σ a) (remap_vars k σ b)
 
-def FV : Π {A : type}, term A → finset ℕ
-| _ (var n A)  := {n}
-| _ ⁎          := ∅
-| _ top        := ∅
-| _ bot        := ∅
-| _ (prod a b) := FV a ∪ FV b
-| _ (a ∈ α)    := FV a ∪ FV α
-| _ (comp A φ) := ((FV φ).erase 0).image nat.pred
-| _ (p ∧' q)   := FV p ∪ FV q
-| _ (p ∨' q)   := FV p ∪ FV q
-| _ (p ⟹ q)  := FV p ∪ FV q
-| _ (∀' A φ)   := ((FV φ).erase 0).image nat.pred
-| _ (∃' A φ)   := ((FV φ).erase 0).image nat.pred
+inductive proof : context → term → term → Prop
+-- c1-3??
+| axm        {Γ φ}     : WF Γ φ Ω → proof Γ φ φ
+| vac        {Γ φ}     : WF Γ φ Ω → proof Γ φ term.top
+| abs        {Γ φ}     : WF Γ φ Ω → proof Γ term.bot φ
+| cut        {Γ φ ψ γ} : proof Γ φ ψ → proof Γ ψ γ → proof Γ φ γ
+| and_intro  {Γ p q r} : proof Γ p q → proof Γ p r → proof Γ p (q ∧' r)  
+| and_left   {Γ p q r} : proof Γ p (q ∧' r) → proof Γ p q
+| and_right  {Γ p q r} : proof Γ p (q ∧' r) → proof Γ p r
+| or_intro   {Γ p q r} : proof Γ p r → proof Γ q r → proof Γ (p ∨' q) r  
+| or_left    {Γ p q r} : proof Γ (p ∨' q) r → proof Γ p r
+| or_right   {Γ p q r} : proof Γ (p ∨' q) r → proof Γ q r
+| imp_to_and {Γ p q r} : proof Γ p (q ⟹ r) → proof Γ (p ∧' q) r
+| and_to_imp {Γ p q r} : proof Γ (p ∧' q) r → proof Γ p (q ⟹ r)
 
-∀ A ∀ A ((var 0 A) = (var 1 B))
+| apply    {Γ φ ψ b B} :
+    WF Γ b B
+    → proof (B::Γ) φ ψ
+    → proof Γ (subst b φ) (subst b ψ) -- can free vars in b become bound?? (bad)
 
-def WF : Π A : type, term A → context → Prop
-| _ (var n A) Γ  := Γ.nth n = some A
-| _ (comp A φ) Γ := WF Ω φ (A :: Γ)
-| _ (∀' A φ) Γ   := WF Ω φ (A :: Γ)
-| _ (∃' A φ) Γ   := WF Ω φ (A :: Γ)
-| _ ⁎ Γ          := true
-| _ top Γ        := true
-| _ bot Γ        := true
-| _ (prod a b) Γ := WF _ a Γ ∧ WF _ b Γ
-| _ (a ∈ α) Γ    := WF _ a Γ ∧ WF _ α Γ
-| _ (p ∧' q) Γ   := WF _ p Γ ∧ WF _ q Γ
-| _ (p ∨' q) Γ   := WF _ p Γ ∧ WF _ q Γ
-| _ (p ⟹ q) Γ  := WF _ p Γ ∧ WF _ q Γ
+| all_elim   {Γ p φ B} : proof (B::Γ) p (all φ) → proof Γ p φ
+| all_intro  {Γ p φ B} : proof Γ p φ → proof (B::Γ) p (∀' φ)
+| ex_elim    {Γ p φ B} : proof (B::Γ) p (∃' φ) → proof Γ p φ
+| ex_intro   {Γ p φ B} : proof Γ p φ → proof (B::Γ) p (∃' φ)
 
-inductive entX : finset ℕ → term Ω → term Ω → Type
-| axm                {Γ p} : entX Γ p p
-| vac                {Γ p} : entX Γ p ⊤
-| abs                {Γ p} : entX Γ ⊥ p
-| cut            {Γ p q r} : entX Γ p q → entX Γ q r → entX Γ p r
-| and_intro      {Γ p q r} : entX Γ r p → entX Γ r q → entX Γ r (p ∧' q) 
-| and_elim_left  {Γ p q r} : entX Γ r (p ∧' q) → entX Γ r p 
-| and_elim_right {Γ p q r} : entX Γ r (p ∧' q) → entX Γ r q
-| or_intro       {Γ p q r} : entX Γ p r → entX Γ q r → entX Γ (p ∨' q) r
-| or_elim_left   {Γ p q r} : entX Γ (p ∨' q) r → entX Γ p r
-| or_elim_right  {Γ p q r} : entX Γ (p ∨' q) r → entX Γ q r
-| imp_to_and     {Γ p q r} : entX Γ p (q ⟹ r) → entX Γ (p ∧' q) r
-| and_to_imp     {Γ p q r} : entX Γ (p ∧' q) r → entX Γ p (q ⟹ r)
-| con_intro {Γ p q} (n : ℕ)
-  : entX (Γ ∪ {n}) p q
-| ext {A : type}
-  : entX ∅ ⊤ $
-    ∀' (𝒫 A) $ ∀' (𝒫 A) $ ∀' A 
-      ((0∶A ∈ 2∶(𝒫 A)) ⇔ (0∶A ∈ 1∶(𝒫 A)))
-      ⟹ 
-      (1∶(𝒫 A) ≃ 0∶(𝒫 A))
-| ext_Ω  
-  : entX ∅ ⊤ $ ∀' Ω $ ∀' Ω $ ((0∶Ω ⇔ 1∶Ω) ⟹ (0∶Ω ≃ 1∶Ω))
-| star_unique : entX ∅ ⊤ $ ∀' 𝟙 (0∶𝟙 ≃ ⁎)
-| product_exists_rep {A B : type}
-  : entX ∅ ⊤ $ ∀' (A ×× B) $ ∃' A $ ∃' B $ (2∶(A ×× B)) ≃ (prod (1∶A) (0∶B))
-| product_distinct_rep {A B : type}
-  : entX ∅ ⊤ $ ∀' A $ ∀' A $ ∀' B $ ∀' B $
-    ((prod (3∶A) (1∶B)) ≃ (prod (2∶A) (0∶B)))
-    ⟹
-    ((3∶A ≃ 2∶A) ∧' (1∶B ≃ 0∶B))
+| comp       {Γ φ A}   :
+    WF (A::A::Γ) φ Ω
+    → proof Γ ⊤
+      (∀' (<0> ∈ (comp φ)) ⇔ (subst <0> φ))
 
-def ent := entX ∅
-def proofX (X: finset ℕ) := entX X ⊤
-def proof := proofX ∅
+| ext                  :
+    proof [] ⊤ $ 
+      ∀' ∀' (∀' (<0> ∈ <2>) ⇔ (<0> ∈ <1>)) ⟹ (<1> ≃ <0>)
+
+| prop_ext             : proof [] ⊤ ∀' ∀' (<1> ⇔ <0>) ⟹ (<1> ≃ <0>)
+| star_unique          : proof [] ⊤ ∀' (<0> ≃ ⁎)
+| prod_exists_rep      : proof [] ⊤ ∀' ∃' ∃' (<2> ≃ (prod <1> <0>))
+
+| prod_distinct_rep    :
+    proof [] ⊤
+      ∀' ∀' ∀' ∀' (prod <3> <1> ≃ prod <2> <0>) ⟹ (<3> ≃ <2> ∧' <1> ≃ <0>)
+
+example : proof [] ⊤ ⊤ := proof.axm WF.top
+
+lemma proof_WF {Γ : context} {P Q: term} : WF Γ P Ω → proof Γ P Q → WF Γ Q Ω := sorry
+
+def FV {Γ : context} {A : type} (a : term): WF Γ a A → context := λ _, Γ
 
 end TT

--- a/src/TL.lean
+++ b/src/TL.lean
@@ -26,6 +26,10 @@ inductive term : Type
 
 open term
 
+-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
+-- Notation and derived operators 
+-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
+
 notation `<0>` := var 0
 notation `<1>` := var 1
 notation `<2>` := var 2
@@ -41,61 +45,65 @@ notation `⁎` := star    -- input \asterisk
 notation `⊤` := top     --       \top
 notation `⊥` := bot     -- input \bot
 infixr ` ⟹ `:60 := imp -- input \==>
-infixr ` ∧' ` :70 := and -- input \wedge'
-infixr ` ∨' ` :59 := or  -- input \vee'
+infixr ` ⊓ ` :70 := and -- input \glb or \sqcap
+infixr ` ⊔ ` :59 := or  -- input \lub or ⊔
 
 def not (p : term) := p ⟹ ⊥
 prefix `∼`:max := not -- input \~, the ASCII character ~ has too low precedence
 
-def biimp (p q: term) := and (p ⟹ q) (q ⟹ p)
+def biimp (p q: term) := (p ⟹ q) ⊓ (q ⟹ p)
 infix ` ⇔ `:60 := biimp -- input \<=>
 
 infix ∈ := elem
 infix ∉ := λ a, λ α, not (elem a α)
-notation `⁅` φ `⁆` := comp φ
+notation `⟦` φ `⟧` := comp φ
+
+infix `××` :max := prod
 
 prefix `∀'`:1 := all 
-prefix `∃'`:2 := ex 
+prefix `∃'`:2 := ex
 
 def eq (a : term) (a' : term) : term := ∀' (a ∈ <0>) ⇔ (a' ∈ <0>)
 infix `≃` :50 := eq
 
-def singleton (a : term) := ⁅a ≃ (<0>)⁆
+def singleton (a : term) := ⟦a ≃ (<0>)⟧
 
 def ex_unique (φ : term) : term :=
-  ∃' ⁅φ⁆ ≃ singleton (<3>)
+  ∃' ⟦φ⟧ ≃ singleton (<3>)
 prefix `∃!'`:2 := ex_unique
 
 def subseteq (α : term) (β : term) : term :=
   ∀' (<0> ∈ α) ⟹ (<0> ∈ β)
 infix ⊆ := subseteq
 
+-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 inductive WF : context → term → type → Prop
 | star {Γ}           : WF Γ term.star 𝟙
 | top  {Γ}           : WF Γ term.top Ω
 | bot  {Γ}           : WF Γ term.bot Ω
-| and  {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (term.and e₁ e₂) Ω
-| or   {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (term.or e₁ e₂) Ω
-| imp  {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (term.imp e₁ e₂) Ω
-| var  {Γ n A}       : list.nth Γ n = some A → WF Γ (term.var n) A
-| comp {Γ e A}       : WF (A::Γ) e Ω → WF Γ (term.comp e) (𝒫 A)
-| all  {Γ e A}       : WF (A::Γ) e Ω → WF Γ (term.all e) Ω
-| ex   {Γ e A}       : WF (A::Γ) e Ω → WF Γ (term.all e) Ω
-| elem {Γ e₁ e₂ A}   : WF Γ e₁ A → WF Γ e₂ (𝒫 A) → WF Γ (term.elem e₁ e₂) Ω
-| prod {Γ e₁ e₂ A B} : WF Γ e₁ A → WF Γ e₂ B → WF Γ (term.prod e₁ e₂) (A ×× B)
+| and  {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (e₁ ⊓ e₂) Ω
+| or   {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (e₁ ⊔ e₂) Ω
+| imp  {Γ e₁ e₂}     : WF Γ e₁ Ω → WF Γ e₁ Ω → WF Γ (e₁ ⟹ e₂) Ω
+| var  {Γ n A}       : list.nth Γ n = some A → WF Γ (var n) A
+| comp {Γ e A}       : WF (A::Γ) e Ω → WF Γ ⟦e⟧ (𝒫 A)
+| all  {Γ e A}       : WF (A::Γ) e Ω → WF Γ (∀' e) Ω
+| ex   {Γ e A}       : WF (A::Γ) e Ω → WF Γ (∃' e) Ω
+| elem {Γ e₁ e₂ A}   : WF Γ e₁ A → WF Γ e₂ (𝒫 A) → WF Γ (e₁ ∈ e₂) Ω
+| prod {Γ e₁ e₂ A B} : WF Γ e₁ A → WF Γ e₂ B → WF Γ (prod e₁ e₂) (A ×× B)
 
 def subst_nth (b:term) : ℕ → term → term
 | n star       := star
 | n top        := top
 | n bot        := bot
-| n (and p q)  := and (subst_nth n p) (subst_nth n q)
-| n (or p q)   := or (subst_nth n p) (subst_nth n q)
-| n (imp p q)  := imp (subst_nth n p) (subst_nth n q)
+| n (p ⊓ q)    := (subst_nth n p) ⊓ (subst_nth n q)
+| n (p ⊔ q)    := (subst_nth n p) ⊔ (subst_nth n q)
+| n (p ⟹ q)  := (subst_nth n p) ⟹ (subst_nth n q)
 | n (var m)    := if n=m then b else var m
-| n (comp φ)   := comp (subst_nth (n+1) φ)
-| n (all φ)    := all (subst_nth (n+1) φ)
-| n (ex φ)     := ex (subst_nth (n+1) φ)
-| n (elem a α) := elem (subst_nth n a) (subst_nth n α)
+| n ⟦φ⟧        := ⟦subst_nth (n+1) φ⟧
+| n (∀' φ)     := ∀' (subst_nth (n+1) φ)
+| n (∃' φ)     := ∃' (subst_nth (n+1) φ)
+| n (a ∈ α)    := (subst_nth n a) ∈ (subst_nth n α)
 | n (prod a b) := prod (subst_nth n a) (subst_nth n b)
 
 def subst (b:term):= subst_nth b 0
@@ -104,30 +112,30 @@ def remap_vars : Π k : ℕ, (ℕ → ℕ) → term → term
 | k σ top        := top
 | k σ star       := star
 | k σ bot        := bot
-| k σ (p ∧' q)   := (remap_vars k σ p) ∧' (remap_vars k σ q)
-| k σ (p ∨' q)   := (remap_vars k σ p) ∨' (remap_vars k σ q)
+| k σ (p ⊓ q)   := (remap_vars k σ p) ⊓ (remap_vars k σ q)
+| k σ (p ⊔ q)   := (remap_vars k σ p) ⊔ (remap_vars k σ q)
 | k σ (p ⟹ q)  := (remap_vars k σ p) ⟹ (remap_vars k σ q)
 | k σ (var m)    := var (σ (m+k))
-| k σ (⁅φ⁆)      := ⁅(remap_vars (k+1) σ φ)⁆
-| k σ (∀' φ)     := ∀' (remap_vars (k+1) σ φ)
-| k σ (∃' φ)     := ex (remap_vars (k+1) σ φ)
+| k σ ⟦φ⟧         := ⟦remap_vars (k+1) σ φ⟧
+| k σ (∀' φ)     := ∀' remap_vars (k+1) σ φ
+| k σ (∃' φ)     := ∃' remap_vars (k+1) σ φ
 | k σ (a ∈ α)    := (remap_vars k σ a) ∈ (remap_vars k σ α)
 | k σ (prod a b) := prod (remap_vars k σ a) (remap_vars k σ b)
 
 inductive proof : context → term → term → Prop
--- c1-3??
+-- c1-3 unecessary?? (because free variables must appear in context)
 | axm        {Γ φ}     : WF Γ φ Ω → proof Γ φ φ
 | vac        {Γ φ}     : WF Γ φ Ω → proof Γ φ term.top
 | abs        {Γ φ}     : WF Γ φ Ω → proof Γ term.bot φ
 | cut        {Γ φ ψ γ} : proof Γ φ ψ → proof Γ ψ γ → proof Γ φ γ
-| and_intro  {Γ p q r} : proof Γ p q → proof Γ p r → proof Γ p (q ∧' r)  
-| and_left   {Γ p q r} : proof Γ p (q ∧' r) → proof Γ p q
-| and_right  {Γ p q r} : proof Γ p (q ∧' r) → proof Γ p r
-| or_intro   {Γ p q r} : proof Γ p r → proof Γ q r → proof Γ (p ∨' q) r  
-| or_left    {Γ p q r} : proof Γ (p ∨' q) r → proof Γ p r
-| or_right   {Γ p q r} : proof Γ (p ∨' q) r → proof Γ q r
-| imp_to_and {Γ p q r} : proof Γ p (q ⟹ r) → proof Γ (p ∧' q) r
-| and_to_imp {Γ p q r} : proof Γ (p ∧' q) r → proof Γ p (q ⟹ r)
+| and_intro  {Γ p q r} : proof Γ p q → proof Γ p r → proof Γ p (q ⊓ r)  
+| and_left   {Γ p q r} : proof Γ p (q ⊓ r) → proof Γ p q
+| and_right  {Γ p q r} : proof Γ p (q ⊓ r) → proof Γ p r
+| or_intro   {Γ p q r} : proof Γ p r → proof Γ q r → proof Γ (p ⊔ q) r  
+| or_left    {Γ p q r} : proof Γ (p ⊔ q) r → proof Γ p r
+| or_right   {Γ p q r} : proof Γ (p ⊔ q) r → proof Γ q r
+| imp_to_and {Γ p q r} : proof Γ p (q ⟹ r) → proof Γ (p ⊓ q) r
+| and_to_imp {Γ p q r} : proof Γ (p ⊓ q) r → proof Γ p (q ⟹ r)
 
 | apply    {Γ φ ψ b B} :
     WF Γ b B
@@ -142,7 +150,7 @@ inductive proof : context → term → term → Prop
 | comp       {Γ φ A}   :
     WF (A::A::Γ) φ Ω
     → proof Γ ⊤
-      (∀' (<0> ∈ (comp φ)) ⇔ (subst <0> φ))
+      (∀' (<0> ∈ ⟦φ⟧) ⇔ (subst <0> φ))
 
 | ext                  :
     proof [] ⊤ $ 
@@ -154,11 +162,15 @@ inductive proof : context → term → term → Prop
 
 | prod_distinct_rep    :
     proof [] ⊤
-      ∀' ∀' ∀' ∀' (prod <3> <1> ≃ prod <2> <0>) ⟹ (<3> ≃ <2> ∧' <1> ≃ <0>)
+      ∀' ∀' ∀' ∀' (prod <3> <1> ≃ prod <2> <0>) ⟹ (<3> ≃ <2> ⊓ <1> ≃ <0>)
 
 example : proof [] ⊤ ⊤ := proof.axm WF.top
 
 lemma proof_WF {Γ : context} {P Q: term} : WF Γ P Ω → proof Γ P Q → WF Γ Q Ω := sorry
+
+variables p q r : term
+
+example {Γ : context}  : proof Γ ⊤ (q ⟹ r) → proof Γ q r := sorry
 
 def FV {Γ : context} {A : type} (a : term): WF Γ a A → context := λ _, Γ
 

--- a/src/TL.lean
+++ b/src/TL.lean
@@ -12,39 +12,47 @@ prefix 𝒫 :101 := type.Pow
 def context := list type
 
 inductive term : context → type → Type
--- _eq is temporary
--- | _eq  (Γ) : Π A : type, term Γ A → term Γ A → term Γ Ω
-| var (Γ A Δ) : term (list.append Γ (A :: Δ)) A
-| comp (Γ) : Π A : type, term (A::Γ) Ω → term Γ (𝒫 A)
-| all  (Γ) : Π A : type, term (A::Γ) Ω → term Γ Ω
-| ex   (Γ) : Π A : type, term (A::Γ) Ω → term Γ Ω
-| star (Γ) : term Γ 𝟙
-| top  (Γ) : term Γ Ω
-| bot  (Γ) : term Γ Ω
-| prod (Γ) : Π {A B : type}, term Γ A → term Γ B → term Γ (A ×× B)
-| elem (Γ) : Π {A : type}, term Γ A → term Γ (𝒫 A) → term Γ Ω
-| and  (Γ) : term Γ Ω → term Γ Ω → term Γ Ω
-| or   (Γ) : term Γ Ω → term Γ Ω → term Γ Ω
-| imp  (Γ) : term Γ Ω → term Γ Ω → term Γ Ω
+| var (Γ A Δ) : term (list.append Γ (A::Δ)) A
+| comp {Γ} : Π A : type, term (A::Γ) Ω → term Γ (𝒫 A)
+| all  {Γ} : Π A : type, term (A::Γ) Ω → term Γ Ω
+| ex   {Γ} : Π A : type, term (A::Γ) Ω → term Γ Ω
+| star {Γ} : term Γ 𝟙
+| top  {Γ} : term Γ Ω
+| bot  {Γ} : term Γ Ω
+| prod {Γ} : Π {A B : type}, term Γ A → term Γ B → term Γ (A ×× B)
+| elem {Γ} : Π {A : type}, term Γ A → term Γ (𝒫 A) → term Γ Ω
+| and  {Γ} : term Γ Ω → term Γ Ω → term Γ Ω
+| or   {Γ} : term Γ Ω → term Γ Ω → term Γ Ω
+| imp  {Γ} : term Γ Ω → term Γ Ω → term Γ Ω
+| fake_eq {Γ} : Π (A : type), term Γ A → term Γ A → term Γ Ω
 
 open term
 
--- def mod_context (Δ : context) (A: type): Π (Γ: context), ℕ → term (list.append Γ) A → term (list.append Γ (F::Δ)) A
--- | (Γ) (n) (all _)
+-- def add_junk (β : context) : Π (Γ: context) (A: type), term Γ A → term (list.append Γ β) A
+-- | (list.append Γ (A::Δ)) (A) (var Γ A Δ) := var Γ A (list.append Δ β)
 
--- x == y
+-- #check var [𝟙,Ω] 𝟙 []
+-- #check var [] 𝟙 [Ω,𝟙]
+
+-- -- x == y
 -- def x_eq_y
---   := _eq [𝟙,Ω,𝟙] 𝟙 (var [𝟙,Ω] 𝟙 []) (var [] 𝟙 [Ω,𝟙])
+--   := fake_eq 𝟙 (var [𝟙,Ω] 𝟙 []) (var [] 𝟙 [Ω,𝟙])
 
--- -- (∀ y ∈ 𝟙) x == y
+-- #check x_eq_y
+
+-- -- x == y
+-- def x_eq_y
+--   := fake_eq [𝟙,Ω,𝟙] 𝟙 (var [𝟙,Ω] 𝟙 []) (var [] 𝟙 [Ω,𝟙])
+
+-- -- -- (∀ y ∈ 𝟙) x == y
 -- def forall_y_x_eq_y
 --   := all [Ω,𝟙] 𝟙 x_eq_y
 
--- -- p ∨ (∀ y ∈ 𝟙) x == y
+-- -- -- p ∨ (∀ y ∈ 𝟙) x == y
 -- def p_or_forall_y_x_eq_y
 --   := or [Ω, 𝟙] (var [] Ω [𝟙]) forall_y_x_eq_y
 
--- -- (∀ p ∈ Ω) (p ∨ (∀ y ∈ 𝟙) x == y)
+-- -- -- (∀ p ∈ Ω) (p ∨ (∀ y ∈ 𝟙) x == y)
 -- def forall_p_p_or_forall_y_x_eq_y
 --   := all [𝟙] Ω p_or_forall_y_x_eq_y
 


### PR DESCRIPTION
This looks like the way to go.

Terms are easy to construct, proofs can be introduced via the well-formedness predicate, and this well-formedness is preserved between proofs without needing to reprove WF'ness.